### PR TITLE
Group state transitions when in a sub-state with 0 transitions

### DIFF
--- a/src/stateMachine.c
+++ b/src/stateMachine.c
@@ -50,7 +50,8 @@ int stateM_handleEvent( struct stateMachine *fsm,
       return stateM_errorStateReached;
    }
 
-   if ( !fsm->currentState->numTransitions )
+   if ( !fsm->currentState->numTransitions && (!fsm->currentState->parentState ||
+	   		   (fsm->currentState->parentState && !fsm->currentState->parentState->numTransitions)) )
       return stateM_noStateChange;
 
    struct state *nextState = fsm->currentState;


### PR DESCRIPTION
When in a sub-state with 0 transitions the state machine will not check the parent state transitions and the state machine is effectively stuck. This commit should fix this problem. 